### PR TITLE
Fix path of spun intermediate Rmd file

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -273,8 +273,7 @@ ezknitr_helper <- function(type,
   # in a few simple steps
   if (type == "ezspin") {
     knitr::spin(file, format = "Rmd", knit = FALSE, ...)
-    file.rename(fileRmdOrig,
-                fileRmd)
+    fileRmd <- fileRmdOrig
   } else if (type == "ezknit") {
     fileRmd <- file
   }

--- a/R/core.R
+++ b/R/core.R
@@ -110,12 +110,14 @@ ezspin <- function(file, wd, out_dir, fig_dir, out_suffix,
                    verbose = FALSE,
                    chunk_opts = list(tidy = FALSE),
                    keep_rmd = FALSE, keep_md = TRUE, keep_html = TRUE,
+                   move_intermediate_file = TRUE,
                    ...) {
   ezknitr_helper(type = "ezspin",
                  file = file, wd = wd, out_dir = out_dir,
                  fig_dir = fig_dir, out_suffix = out_suffix,
                  params = params, verbose = verbose, chunk_opts = chunk_opts,
                  keep_rmd = keep_rmd, keep_md = keep_md, keep_html = keep_html,
+                 move_intermediate_file = move_intermediate_file,
                  ...)
 }
 
@@ -142,6 +144,7 @@ ezknitr_helper <- function(type,
                            verbose = FALSE,
                            chunk_opts = list(tidy = FALSE),
                            keep_rmd, keep_md, keep_html,
+                           move_intermediate_file = TRUE,
                            ...) {
   type <- match.arg(type, c("ezspin", "ezknit"))
   
@@ -273,7 +276,12 @@ ezknitr_helper <- function(type,
   # in a few simple steps
   if (type == "ezspin") {
     knitr::spin(file, format = "Rmd", knit = FALSE, ...)
-    fileRmd <- fileRmdOrig
+    if (move_intermediate_file) {
+      file.rename(fileRmdOrig,
+                  fileRmd)
+    } else {
+      fileRmd <- fileRmdOrig
+    }
   } else if (type == "ezknit") {
     fileRmd <- file
   }

--- a/R/core.R
+++ b/R/core.R
@@ -48,6 +48,9 @@
 #' kept (\code{TRUE}) or deleted (\code{FALSE})?
 #' @param keep_html Should the final \code{html} file be kept (\code{TRUE})
 #' or deleted (\code{FALSE})?
+#' @param move_intermediate_file Should the intermediate \code{Rmd} file be
+#' moved to the destination folder (\code{TRUE}) or stay in the same folder as
+#' the source \code{R} file (\code{FALSE})?
 #' @param ... Any extra parameters that should be passed to \code{knitr::spin}.
 #'   
 #' @return The path to the output directory (invisibly).

--- a/man/ezknitr_core.Rd
+++ b/man/ezknitr_core.Rd
@@ -8,7 +8,7 @@
 \usage{
 ezspin(file, wd, out_dir, fig_dir, out_suffix, params = list(),
   verbose = FALSE, chunk_opts = list(tidy = FALSE), keep_rmd = FALSE,
-  keep_md = TRUE, keep_html = TRUE, ...)
+  keep_md = TRUE, keep_html = TRUE, move_intermediate_file = TRUE, ...)
 
 ezknit(file, wd, out_dir, fig_dir, out_suffix, params = list(),
   verbose = FALSE, chunk_opts = list(tidy = FALSE), keep_md = TRUE,
@@ -50,6 +50,10 @@ kept (\code{TRUE}) or deleted (\code{FALSE})?}
 
 \item{keep_html}{Should the final \code{html} file be kept (\code{TRUE})
 or deleted (\code{FALSE})?}
+
+\item{move_intermediate_file}{Should the intermediate \code{Rmd} file be
+moved to the destination folder (\code{TRUE}) or stay in the same folder as
+the source \code{R} file (\code{FALSE})?}
 
 \item{...}{Any extra parameters that should be passed to \code{knitr::spin}.}
 }

--- a/tests/testthat/test-ezknitr.R
+++ b/tests/testthat/test-ezknitr.R
@@ -45,6 +45,21 @@ test_that("ezspin creates the correct files", {
          out_dir = "output", fig_dir = "coolplots", keep_rmd = TRUE)
   files <- c(
     file.path(tmp, "R", "ezspin_test.R"),
+    file.path(tmp, "output", "ezspin_test.Rmd"),
+    file.path(tmp, "output", "ezspin_test.md"),
+    file.path(tmp, "output", "ezspin_test.html"),
+    file.path(tmp, "output", "coolplots", "plot-1.png"),
+    file.path(tmp, "data", "numbers.txt")
+  )
+  expect_true(all(file.exists(files)))
+  unlink(tmp, recursive = TRUE, force = TRUE)
+  
+  tmp <- setup_ezspin_test()
+  ezspin("R/ezspin_test.R", wd = "ezknitr_test",
+         out_dir = "output", fig_dir = "coolplots", keep_rmd = TRUE,
+         move_intermediate_file = FALSE)
+  files <- c(
+    file.path(tmp, "R", "ezspin_test.R"),
     file.path(tmp, "R", "ezspin_test.Rmd"),
     file.path(tmp, "output", "ezspin_test.md"),
     file.path(tmp, "output", "ezspin_test.html"),

--- a/tests/testthat/test-ezknitr.R
+++ b/tests/testthat/test-ezknitr.R
@@ -45,7 +45,7 @@ test_that("ezspin creates the correct files", {
          out_dir = "output", fig_dir = "coolplots", keep_rmd = TRUE)
   files <- c(
     file.path(tmp, "R", "ezspin_test.R"),
-    file.path(tmp, "output", "ezspin_test.Rmd"),
+    file.path(tmp, "R", "ezspin_test.Rmd"),
     file.path(tmp, "output", "ezspin_test.md"),
     file.path(tmp, "output", "ezspin_test.html"),
     file.path(tmp, "output", "coolplots", "plot-1.png"),


### PR DESCRIPTION
At the moment, `ezspin` moves the Rmd file produced by `knitr::spin` to the output path.

This is a problem because it changes the environment in which the R/Rmd file is executed. If the R script searches for files relative to its own path, it now won’t find these files because its own path changed. This is what happens, for instance, in [‹modules›](https://github.com/klmr/modules): it uses the path of the currently executed/knit file to search for dependent code modules. This happens via`knitr::current_input(dir = TRUE)`, and it requires that the spun file is in the same path as the source file.

This PR provides a simple fix: instead of moving the intermediate Rmd file to the output path, it leaves it where it is. The old behaviour of `ezspin` is probably never desirable, but very few projects will notice either way, since the path of the current R file is quite hard to retrieve in R usually — in fact, [‹modules› requires some quite complex logic for that](https://github.com/klmr/modules/blob/e626dd3a667d9ed8e5079e9dd5a6eb9f563ba99c/R/module_cache.r#L120-L151). It is therefore safe to assume that this PR will not impact existing _code_.

It _will_ impact the observable result when `keep_rmd = TRUE` is specified, since an intermediate file is now in a different location. However, this parameter is only useful when the intermediate Rmd file is being rerun repeatedly, and — for the reason mentioned in the previous paragraph — it doesn’t matter for most existing R code where the Rmd file is.
